### PR TITLE
add week 11 progress link

### DIFF
--- a/docs/PROGRESS/MVP_CHECKLIST.md
+++ b/docs/PROGRESS/MVP_CHECKLIST.md
@@ -123,4 +123,19 @@
 
 ---
 
-*Last Updated: Week 8 - Midterm*
+### Week 11 — MVP Verification
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Sprint packet created | ✅ Done | [WEEK_11_SPRINT_PACKET.md](../week11/WEEK_11_SPRINT_PACKET.md) |
+| Bug list documented | ✅ Done | [BUG_LIST.md](../week11/BUG_LIST.md) |
+| Ownership map created | ✅ Done | [OWNERSHIP_MAP.md](../week11/OWNERSHIP_MAP.md) |
+| Demo script written | ✅ Done | [WEEK_11_DEMO_SCRIPT.md](../week11/WEEK_11_DEMO_SCRIPT.md) |
+| Evidence links collected | ✅ Done | [EVIDENCE_LINKS.md](../week11/EVIDENCE_LINKS.md) |
+| MVP checklist updated | ✅ Done | [MVP_VERIFICATION_CHECKLIST.md](../week11/MVP_VERIFICATION_CHECKLIST.md) |
+| Screenshots folder ready | ✅ Done | [docs/evidence/week11/](../evidence/week11/README.md) |
+| Core flow verified | ✅ Done | All 7 steps working |
+
+---
+
+*Last Updated: Week 11 - MVP Verification*

--- a/docs/PROGRESS/MVP_WEEK_11.md
+++ b/docs/PROGRESS/MVP_WEEK_11.md
@@ -1,0 +1,103 @@
+# MVP Week 11 Progress — MVP Verification
+
+## Week 11 Goal
+Validate the MVP core flow end to end. Show evidence, list bugs, map ownership, and prepare the sprint packet for the demo.
+
+---
+
+## Core MVP Flow
+
+1. User opens Free Sewaa landing page
+2. User signs up or logs in
+3. User browses donation items
+4. User posts a donation item
+5. Another user requests or contacts donor
+6. Admin reviews the platform
+7. Team shows proof (screenshots, PRs, test results, docs, reviews, CI)
+
+---
+
+## What We Verified
+
+- Signup and login work with demo accounts
+- Browse page shows available items with search and filter
+- Donate form accepts new item posts
+- Messages page shows chat inbox
+- Admin login and panel are accessible
+- All 7 core flow steps are functional
+
+---
+
+## Evidence Links
+
+| Type | Link |
+|------|------|
+| Full Week 11 Overview | [docs/week11/README.md](../week11/README.md) |
+| Sprint Packet | [docs/week11/WEEK_11_SPRINT_PACKET.md](../week11/WEEK_11_SPRINT_PACKET.md) |
+| MVP Checklist | [docs/week11/MVP_VERIFICATION_CHECKLIST.md](../week11/MVP_VERIFICATION_CHECKLIST.md) |
+| Demo Script | [docs/week11/WEEK_11_DEMO_SCRIPT.md](../week11/WEEK_11_DEMO_SCRIPT.md) |
+| Bug List | [docs/week11/BUG_LIST.md](../week11/BUG_LIST.md) |
+| Ownership Map | [docs/week11/OWNERSHIP_MAP.md](../week11/OWNERSHIP_MAP.md) |
+| Evidence Links | [docs/week11/EVIDENCE_LINKS.md](../week11/EVIDENCE_LINKS.md) |
+| Week 11 Screenshots | [docs/evidence/week11/README.md](../evidence/week11/README.md) |
+
+---
+
+## Bug List Summary
+
+| Priority | Count | Examples |
+|----------|-------|----------|
+| P0 | 1 | Password stored in plaintext |
+| P1 | 4 | Login restart needed, no validation, no unit tests, CI not testing |
+| P2 | 5 | No image preview, bad search, chat context missing, timestamp bug, no error handling |
+
+Full list: [BUG_LIST.md](../week11/BUG_LIST.md)
+
+---
+
+## Ownership Map
+
+| Name | Role |
+|------|------|
+| Ram Pathak | Project Management |
+| Sujan Tamang | Frontend |
+| Mohan Khadka | Demo |
+| Sujan Shrestha | Testing / QA |
+| Swarnim Jung Karki | Documentation / Repo Management |
+
+Full map: [OWNERSHIP_MAP.md](../week11/OWNERSHIP_MAP.md)
+
+---
+
+## Demo Plan
+
+| Segment | Time | Who |
+|---------|------|-----|
+| PM update / what improved | 45 sec | Ram Pathak |
+| Demo MVP core flow | 2 min | Mohan Khadka |
+| QA evidence and test results | 1 min | Sujan Shrestha |
+| Random team member explains one part | 1 min | Any member |
+
+Full script: [WEEK_11_DEMO_SCRIPT.md](../week11/WEEK_11_DEMO_SCRIPT.md)
+
+---
+
+## Current Track
+
+**Track B — MVP Stabilization**
+
+Reason: The app mostly works, but we still need stronger evidence, bug tracking, documentation, and tests.
+
+Goal: Move toward Track C — MVP Plus (app works well, team understands it, ready for polish).
+
+---
+
+## Next Steps
+
+1. Fix P0 bug (password hashing with bcrypt)
+2. Add unit tests for backend API
+3. Update CI to run tests automatically
+4. Add image upload preview
+5. Improve search accuracy
+6. Fix chat context and timestamp bugs
+7. Close evidence gaps with screenshots and test results

--- a/docs/PROGRESS/README.md
+++ b/docs/PROGRESS/README.md
@@ -1,0 +1,31 @@
+# MVP Progress Reports
+
+Weekly progress tracking for Free Sewaa capstone project.
+
+---
+
+## Week-by-Week Progress
+
+| Week | Title | Link |
+|------|-------|------|
+| Week 1 | Onboarding & Setup | [MVP_WEEK_1.md](MVP_WEEK_1.md) |
+| Week 2 | Reset Week & Planning | [MVP_WEEK_2.md](MVP_WEEK_2.md) |
+| Week 3 | Frontend MVP | [MVP_WEEK_3.md](MVP_WEEK_3.md) |
+| Week 4 | Browse & Filtering | [MVP_WEEK_4.md](MVP_WEEK_4.md) |
+| Week 5 | Premium UI Redesign | [MVP_WEEK_5.md](MVP_WEEK_5.md) |
+| Week 6 | Backend Foundation | [MVP_WEEK_6.md](MVP_WEEK_6.md) |
+| Week 7 | Midterm Preparation | — |
+| Week 8 | Midterm Presentation | — |
+| Week 9 | Polish & Testing | — |
+| Week 10 | Bug Triage | — |
+| Week 11 | MVP Verification | [MVP_WEEK_11.md](MVP_WEEK_11.md) |
+
+---
+
+## Key Documents
+
+| Document | Description |
+|----------|-------------|
+| [MVP_CHECKLIST.md](MVP_CHECKLIST.md) | Full feature checklist with status |
+| [TESTING_LOG.md](TESTING_LOG.md) | Testing log and results |
+| [docs/week11/](../week11/README.md) | Week 11 full documentation folder |


### PR DESCRIPTION
# Pull Request

## Summary
This PR adds Week 11 progress documentation and connects it with the existing Week 11 MVP Verification folder. It helps show our MVP flow, evidence, bug list, ownership map, and demo plan.

## Related Issue
Closes # 

## What changed
- Added Week 11 progress documentation in `docs/PROGRESS`
- Linked Week 11 progress file to the `docs/week11` folder
- Added links to Sprint Packet, MVP Checklist, Demo Script, Bug List, Ownership Map, and Evidence Links
- Updated progress documentation so the professor can easily review Week 11 work
- Organized the documentation for MVP verification and demo preparation

## How I tested
- Checked that the new Markdown file opens correctly
- Checked that the links point to the correct Week 11 documents
- Reviewed the content for simple English and clear structure
- Ran `git status` to confirm the changed files
- Confirmed that no application logic was changed

## Screenshot / Evidence
- Week 11 folder: `docs/week11/`
- Progress file: `docs/PROGRESS/MVP_WEEK_11.md`
- Evidence folder: `docs/evidence/week11/`
- Sprint Packet: `docs/week11/WEEK_11_SPRINT_PACKET.md`
- Bug List: `docs/week11/BUG_LIST.md`
- Ownership Map: `docs/week11/OWNERSHIP_MAP.md`

## AI Use Note
- AI tool used: ChatGPT / Copilot
- What AI helped with: AI helped draft and organize the Week 11 documentation structure, progress report, checklist, and PR text.
- What I personally checked or changed: I checked the file names, folder links, Week 11 requirements, and made sure the documentation matches our Free Sewaa project.
- How I tested it: I reviewed the Markdown files, checked the links, and confirmed that the documentation is clear and organized.
- One part I still do not fully understand: I need to understand more clearly how to connect every evidence item with its exact Issue, PR, screenshot, and CI run link.