### PR TITLE
Restrict authentication to Gmail accounts

### DIFF
--- a/html/admin_login.html
+++ b/html/admin_login.html
@@ -54,8 +54,8 @@
 
       <form class="auth-form" id="adminLoginForm" novalidate>
         <label class="field">
-          <span>Email address</span>
-          <input id="adminEmail" type="email" placeholder="Enter your admin email" autocomplete="username" required />
+          <span>Admin Gmail address</span>
+          <input id="adminEmail" type="email" placeholder="admin@gmail.com" autocomplete="username" required />
         </label>
         <label class="field">
           <span>Password</span>
@@ -174,7 +174,11 @@
       const email = document.getElementById('adminEmail').value.trim();
       const password = document.getElementById('adminPassword').value;
       if (!email || !password) {
-        showMessage('Please enter your email and password.');
+        showMessage('Please enter your admin Gmail address and password.');
+        return;
+      }
+      if (!/^[a-z0-9._%+-]+@gmail\.com$/i.test(email)) {
+        showMessage('Please use an admin Gmail address ending in @gmail.com.');
         return;
       }
       submitBtn.disabled = true;

--- a/html/signin.html
+++ b/html/signin.html
@@ -42,7 +42,7 @@ if (localStorage.getItem('freesewaa-auth') === 'true' && localStorage.getItem('f
       <div class="auth-card__top">
         <p class="eyebrow">SIGN IN</p>
         <h2>Welcome back</h2>
-        <p class="auth-card__text">Choose the way you want to sign in.</p>
+        <p class="auth-card__text">Sign in with your verified Gmail account.</p>
       </div>
 
       <div class="social-row">
@@ -57,15 +57,14 @@ if (localStorage.getItem('freesewaa-auth') === 'true' && localStorage.getItem('f
       <div class="divider"><span>or</span></div>
 
       <div class="auth-toggle">
-        <button class="toggle-btn is-active" data-panel-target="emailPanel">Email</button>
-        <button class="toggle-btn" data-panel-target="phonePanel">Phone Number</button>
+        <button class="toggle-btn is-active" data-panel-target="emailPanel">Gmail</button>
       </div>
 
       <div class="auth-panel is-active" id="emailPanel">
         <form class="auth-form" data-auth-panel="email">
           <label class="field">
-            <span>Email address</span>
-            <input type="email" placeholder="you@example.com" />
+            <span>Gmail address</span>
+            <input type="email" placeholder="you@gmail.com" autocomplete="email" />
           </label>
           <label class="field">
             <span>Password</span>
@@ -76,25 +75,6 @@ if (localStorage.getItem('freesewaa-auth') === 'true' && localStorage.getItem('f
             <a href="#" class="text-link">Forgot password?</a>
           </div>
           <button class="primary-btn" type="submit">Sign In</button>
-        </form>
-      </div>
-
-      <div class="auth-panel" id="phonePanel">
-        <form class="auth-form" data-auth-panel="phone">
-          <label class="field">
-            <span>Phone number</span>
-            <div class="phone-group">
-              <select><option>+1</option><option>+82</option><option>+977</option><option>+44</option><option>+61</option></select>
-              <input type="tel" placeholder="Enter your phone number" />
-            </div>
-          </label>
-          <button class="secondary-btn" type="button" data-phone-action="send-code">Send Verification Code</button>
-          <div id="recaptcha-container" class="recaptcha-container"></div>
-          <label class="field">
-            <span>Verification code</span>
-            <input type="text" placeholder="Enter 6-digit code" />
-          </label>
-          <button class="primary-btn" type="submit">Continue</button>
         </form>
       </div>
 

--- a/html/signup.html
+++ b/html/signup.html
@@ -42,7 +42,7 @@ if (localStorage.getItem('freesewaa-auth') === 'true' && localStorage.getItem('f
       <div class="auth-card__top">
         <p class="eyebrow">SIGN UP</p>
         <h2>Create account</h2>
-        <p class="auth-card__text">Start with Google, email, or phone number.</p>
+        <p class="auth-card__text">Create your account with a verified Gmail address.</p>
       </div>
 
       <div class="social-row">
@@ -57,8 +57,7 @@ if (localStorage.getItem('freesewaa-auth') === 'true' && localStorage.getItem('f
       <div class="divider"><span>or</span></div>
 
       <div class="auth-toggle">
-        <button class="toggle-btn is-active" data-panel-target="emailPanel">Email</button>
-        <button class="toggle-btn" data-panel-target="phonePanel">Phone Number</button>
+        <button class="toggle-btn is-active" data-panel-target="emailPanel">Gmail</button>
       </div>
 
       <div class="auth-panel is-active" id="emailPanel">
@@ -67,29 +66,8 @@ if (localStorage.getItem('freesewaa-auth') === 'true' && localStorage.getItem('f
             <label class="field"><span>First name</span><input type="text" placeholder="First name" /></label>
             <label class="field"><span>Last name</span><input type="text" placeholder="Last name" /></label>
           </div>
-          <label class="field"><span>Email address</span><input type="email" placeholder="you@example.com" /></label>
+          <label class="field"><span>Gmail address</span><input type="email" placeholder="you@gmail.com" autocomplete="email" /></label>
           <label class="field"><span>Password</span><input type="password" placeholder="Create password" /></label>
-          <label class="checkbox"><input type="checkbox" /><span>I agree to the Terms and Privacy Policy</span></label>
-          <button class="primary-btn" type="submit">Create Account</button>
-        </form>
-      </div>
-
-      <div class="auth-panel" id="phonePanel">
-        <form class="auth-form" data-auth-panel="phone">
-          <div class="field-grid">
-            <label class="field"><span>First name</span><input type="text" placeholder="First name" /></label>
-            <label class="field"><span>Last name</span><input type="text" placeholder="Last name" /></label>
-          </div>
-          <label class="field">
-            <span>Phone number</span>
-            <div class="phone-group">
-              <select><option>+1</option><option>+82</option><option>+977</option><option>+44</option><option>+61</option></select>
-              <input type="tel" placeholder="Enter your phone number" />
-            </div>
-          </label>
-          <button class="secondary-btn" type="button" data-phone-action="send-code">Send Verification Code</button>
-          <div id="recaptcha-container" class="recaptcha-container"></div>
-          <label class="field"><span>Verification code</span><input type="text" placeholder="Enter 6-digit code" /></label>
           <label class="checkbox"><input type="checkbox" /><span>I agree to the Terms and Privacy Policy</span></label>
           <button class="primary-btn" type="submit">Create Account</button>
         </form>

--- a/js/auth.js
+++ b/js/auth.js
@@ -88,6 +88,8 @@ const phoneAuthState = {
   sendingForForm: null
 };
 
+const GMAIL_ONLY_MESSAGE = 'Please use a valid Gmail address ending in @gmail.com.';
+
 function getApiBaseUrl() {
   let stored = '';
   try {
@@ -110,6 +112,10 @@ function apiUrl(path) {
   if (/^https?:\/\//i.test(path)) return path;
   if (String(path).startsWith('//')) return `${window.location.protocol}${path}`;
   return new URL(String(path), getApiBaseUrl()).toString();
+}
+
+function isGmailAddress(email = '') {
+  return /^[a-z0-9._%+-]+@gmail\.com$/i.test(String(email || '').trim());
 }
 
 function getPageMode() {
@@ -211,6 +217,7 @@ function validateSignupEmailForm(form, values) {
   if (!firstName) throw new Error('Please enter your first name.');
   if (!lastName) throw new Error('Please enter your last name.');
   if (!email) throw new Error('Please enter your email address.');
+  if (!isGmailAddress(email)) throw new Error(GMAIL_ONLY_MESSAGE);
   if (!password || password.length < 8) throw new Error('Password must be at least 8 characters.');
   if (!agreed) throw new Error('Please agree to the Terms and Privacy Policy.');
 }
@@ -218,6 +225,7 @@ function validateSignupEmailForm(form, values) {
 function validateSigninEmailForm(values) {
   const [email, password] = values;
   if (!email) throw new Error('Please enter your email address.');
+  if (!isGmailAddress(email)) throw new Error(GMAIL_ONLY_MESSAGE);
   if (!password) throw new Error('Please enter your password.');
 }
 
@@ -281,6 +289,10 @@ async function signInWithGoogle(button) {
 
     if (!firebaseUser) {
       throw new Error('Google sign in did not return a user.');
+    }
+
+    if (!isGmailAddress(firebaseUser.email || '') || firebaseUser.emailVerified !== true) {
+      throw new Error('Please choose a verified Gmail account ending in @gmail.com.');
     }
 
     const token = await firebaseUser.getIdToken(true);

--- a/server/server.js
+++ b/server/server.js
@@ -30,6 +30,8 @@ const SUPER_ADMIN_USER_IDS = String(process.env.SUPER_ADMIN_USER_IDS || process.
   .split(',')
   .map(id => id.trim())
   .filter(Boolean);
+const GMAIL_ONLY_MESSAGE = 'Please use a valid Gmail address ending in @gmail.com.';
+const VERIFIED_GMAIL_ONLY_MESSAGE = 'Please sign in with a verified Gmail account.';
 
 if (!MONGODB_URI) {
   console.error('❌ Missing MongoDB connection string. Set MONGODB_URI (or MONGO_URI) in environment variables.');
@@ -920,6 +922,10 @@ async function buildAdminDashboardData() {
   };
 }
 
+function isGmailAddress(email = '') {
+  return /^[a-z0-9._%+-]+@gmail\.com$/i.test(String(email || '').trim());
+}
+
 async function requireAdminUser(req, url) {
   const userId = getUserId(req, url);
   if (!userId) {
@@ -1075,15 +1081,7 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (pathname === '/api/auth/google-demo' && req.method === 'POST') {
-      const user = await usersCollection.findOne({ id: 'user-demo' });
-      if (!user) {
-        return sendJson(res, 404, { error: 'Demo user not found.' });
-      }
-      await ensureStateForUser(user);
-      return sendJson(res, 200, {
-        user: safeUser(user),
-        auth: { userId: user.id, isAuthenticated: true }
-      });
+      return sendJson(res, 410, { error: 'Demo login is disabled. Please sign in with a verified Gmail account.' });
     }
 
     if (pathname === '/api/auth/firebase' && req.method === 'POST') {
@@ -1108,9 +1106,14 @@ const server = http.createServer(async (req, res) => {
       const email = String(claims.email || '').trim().toLowerCase();
       const tokenPhone = String(claims.phone_number || phone || '').replace(/\s+/g, '');
       const authProvider = String(provider || claims.firebase?.sign_in_provider || 'firebase').trim() || 'firebase';
+      const emailVerified = claims.email_verified === true || claims.email_verified === 'true';
 
       if (!firebaseUid) {
         return sendJson(res, 400, { error: 'Firebase token is missing a user id.' });
+      }
+
+      if (!email || !isGmailAddress(email) || !emailVerified) {
+        return sendJson(res, 403, { error: VERIFIED_GMAIL_ONLY_MESSAGE });
       }
 
       const lookup = [{ firebaseUid }];
@@ -1198,6 +1201,10 @@ const server = http.createServer(async (req, res) => {
       }
 
       const role = isConfiguredSuperAdmin(user) ? 'superadmin' : user.role || 'user';
+      if (role !== 'superadmin' && !isGmailAddress(user.email || '')) {
+        return sendJson(res, 403, { error: VERIFIED_GMAIL_ONLY_MESSAGE });
+      }
+
       if (role !== user.role) {
         await usersCollection.updateOne({ id: user.id }, { $set: { role, updatedAt: new Date().toISOString() } });
         user.role = role;
@@ -1214,15 +1221,19 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (pathname === '/api/auth/signup' && req.method === 'POST') {
-      const { firstName = '', lastName = '', email = '', password = '', phone = '' } = await readRequestBody(req);
+      const { firstName = '', lastName = '', email = '', password = '' } = await readRequestBody(req);
 
-      if ((!email && !phone) || !password || !firstName.trim()) {
+      if (!email || !password || !firstName.trim()) {
         return sendJson(res, 400, {
-          error: 'First name, password, and either email or phone are required.'
+          error: 'First name, Gmail address, and password are required.'
         });
       }
 
-      const { normalizedEmail, normalizedPhone, query } = buildAuthQuery(email, phone);
+      const { normalizedEmail, query } = buildAuthQuery(email, '');
+
+      if (!isGmailAddress(normalizedEmail)) {
+        return sendJson(res, 400, { error: GMAIL_ONLY_MESSAGE });
+      }
 
       const existing = query.length
         ? await usersCollection.findOne({ $or: query })
@@ -1247,7 +1258,6 @@ const server = http.createServer(async (req, res) => {
       };
 
       if (normalizedEmail) user.email = normalizedEmail;
-      if (normalizedPhone) user.phone = normalizedPhone;
 
       await usersCollection.insertOne(user);
       await setUserState(user.id, defaultUserState(user));
@@ -1259,12 +1269,16 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (pathname === '/api/auth/signin' && req.method === 'POST') {
-      const { email = '', password = '', phone = '' } = await readRequestBody(req);
+      const { email = '', password = '' } = await readRequestBody(req);
 
-      const { query } = buildAuthQuery(email, phone);
+      const { normalizedEmail, query } = buildAuthQuery(email, '');
 
-      if (!query.length) {
-        return sendJson(res, 400, { error: 'Email or phone is required.' });
+      if (!normalizedEmail) {
+        return sendJson(res, 400, { error: 'Gmail address is required.' });
+      }
+
+      if (!isGmailAddress(normalizedEmail)) {
+        return sendJson(res, 400, { error: GMAIL_ONLY_MESSAGE });
       }
 
       const user = await usersCollection.findOne({ $or: query });
@@ -1292,12 +1306,16 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (pathname === '/api/auth/admin/signin' && req.method === 'POST') {
-      const { email = '', password = '', phone = '' } = await readRequestBody(req);
+      const { email = '', password = '' } = await readRequestBody(req);
 
-      const { query } = buildAuthQuery(email, phone);
+      const { normalizedEmail, query } = buildAuthQuery(email, '');
 
-      if (!query.length) {
-        return sendJson(res, 400, { error: 'Email or phone is required.' });
+      if (!normalizedEmail) {
+        return sendJson(res, 400, { error: 'Admin Gmail address is required.' });
+      }
+
+      if (!isGmailAddress(normalizedEmail)) {
+        return sendJson(res, 400, { error: GMAIL_ONLY_MESSAGE });
       }
 
       const user = await usersCollection.findOne({ $or: query });


### PR DESCRIPTION
## Summary
- Restrict manual signup, signin, and admin signin to `@gmail.com` addresses.
- Require Firebase/Google auth sessions to use a verified Gmail account.
- Disable demo login and remove phone-only auth options from the sign-in and sign-up UI.

## Validation
- `node --check server/server.js`
- `node --check js/auth.js`