### PR TITLE
 Blend portal logo with video background

### DIFF
--- a/client/src/generated-pages/routes.jsx
+++ b/client/src/generated-pages/routes.jsx
@@ -236,7 +236,7 @@ export const pageRoutes = {
         },
         {
           "rel": "stylesheet",
-          "href": "/css/auth.css?v=20260616-video-bgfix"
+          "href": "/css/auth.css?v=20260616-video-blend"
         }
       ],
       "scripts": []
@@ -1043,7 +1043,7 @@ export const pageRoutes = {
         },
         {
           "rel": "stylesheet",
-          "href": "/css/auth.css?v=20260616-video-bgfix"
+          "href": "/css/auth.css?v=20260616-video-blend"
         }
       ],
       "scripts": []

--- a/css/auth.css
+++ b/css/auth.css
@@ -1123,8 +1123,8 @@ body{
 .portal-page .auth-overlay{
   z-index:1;
   background:
-    linear-gradient(90deg,rgba(5,7,8,.16),rgba(255,255,255,.18) 48%,rgba(255,255,255,.28)),
-    linear-gradient(180deg,rgba(5,7,8,.08),rgba(255,255,255,.30));
+    linear-gradient(90deg,rgba(5,7,8,.10),rgba(255,255,255,.10) 48%,rgba(255,255,255,.16)),
+    linear-gradient(180deg,rgba(5,7,8,.06),rgba(255,255,255,.18));
   pointer-events:none;
 }
 
@@ -1276,8 +1276,8 @@ body{
   display:grid;
   align-content:center;
   justify-items:center;
-  gap:28px;
-  padding:clamp(42px,6vw,96px);
+  gap:20px;
+  padding:clamp(30px,5vw,74px);
   border-radius:0;
   background:transparent;
   border:0;
@@ -1292,7 +1292,7 @@ body{
   inset:0;
   z-index:-1;
   background:
-    linear-gradient(90deg,rgba(255,255,255,.08),rgba(255,255,255,.62));
+    radial-gradient(circle at 50% 50%,rgba(255,255,255,.48),rgba(255,255,255,.22) 42%,rgba(255,255,255,.04) 76%,transparent 100%);
   pointer-events:none;
 }
 
@@ -1301,21 +1301,24 @@ body{
   justify-items:center;
   gap:12px;
   text-align:center;
-  width:min(490px,100%);
-  padding:clamp(24px,4vw,42px);
+  width:min(500px,100%);
+  padding:clamp(22px,3.4vw,36px);
   border-radius:8px;
-  background:rgba(255,255,255,.72);
-  border:1px solid rgba(255,255,255,.48);
-  box-shadow:0 24px 70px rgba(20,28,34,.16);
-  backdrop-filter:blur(16px) saturate(122%);
+  background:rgba(255,255,255,.48);
+  border:1px solid rgba(255,255,255,.36);
+  box-shadow:0 24px 70px rgba(20,28,34,.12);
+  backdrop-filter:blur(12px) saturate(118%);
 }
 
 .portal-signin-head img{
-  width:min(210px,50vw);
+  width:min(184px,42vw);
   height:auto;
   object-fit:contain;
-  margin-bottom:18px;
-  filter:drop-shadow(0 18px 30px rgba(39,37,34,.08));
+  margin:0 auto 4px;
+  padding:10px 14px;
+  border-radius:8px;
+  background:rgba(255,255,255,.24);
+  filter:drop-shadow(0 14px 26px rgba(39,37,34,.10));
 }
 
 .portal-quote{
@@ -1370,10 +1373,10 @@ body{
   margin-top:6px;
   padding:18px 22px;
   border-radius:8px;
-  background:rgba(255,255,255,.70);
-  border:1px solid rgba(255,255,255,.46);
-  box-shadow:0 18px 48px rgba(20,28,34,.13);
-  backdrop-filter:blur(14px) saturate(118%);
+  background:rgba(255,255,255,.54);
+  border:1px solid rgba(255,255,255,.38);
+  box-shadow:0 18px 48px rgba(20,28,34,.12);
+  backdrop-filter:blur(12px) saturate(116%);
 }
 
 .portal-page .portal-option{
@@ -1449,7 +1452,7 @@ body{
   margin:0;
   padding:10px 14px;
   border-radius:999px;
-  background:rgba(255,255,255,.64);
+  background:rgba(255,255,255,.48);
   text-align:center;
   display:flex;
   align-items:center;

--- a/html/auth_choice.html
+++ b/html/auth_choice.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Cormorant+Garamond:wght@500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/auth.css?v=20260616-video-bgfix" />
+  <link rel="stylesheet" href="../css/auth.css?v=20260616-video-blend" />
 </head>
 <body class="auth-page portal-page">
   <div class="auth-overlay"></div>


### PR DESCRIPTION
## Summary

- Soften the right-side overlay so the video blends across the whole page.
- Move the logo into the central sign-in content group visually.
- Reduce the white slab effect while keeping sign-in text readable.
- Bump the auth CSS cache version for Render.

## Validation

- Ran npm run build successfully.