### PR TITLE
Center portal sign-in stack

### DIFF
--- a/client/src/generated-pages/routes.jsx
+++ b/client/src/generated-pages/routes.jsx
@@ -236,7 +236,7 @@ export const pageRoutes = {
         },
         {
           "rel": "stylesheet",
-          "href": "/css/auth.css?v=20260616-video-blend"
+          "href": "/css/auth.css?v=20260616-video-center"
         }
       ],
       "scripts": []
@@ -1043,7 +1043,7 @@ export const pageRoutes = {
         },
         {
           "rel": "stylesheet",
-          "href": "/css/auth.css?v=20260616-video-blend"
+          "href": "/css/auth.css?v=20260616-video-center"
         }
       ],
       "scripts": []

--- a/css/auth.css
+++ b/css/auth.css
@@ -1135,22 +1135,22 @@ body{
   max-width:none;
   height:100vh;
   min-height:100vh;
-  grid-template-columns:1fr 1fr;
+  grid-template-columns:1fr;
   gap:0;
-  align-items:stretch;
+  align-items:center;
+  justify-items:center;
   padding:0;
 }
 
 .portal-page .portal-left,
 .portal-page .portal-card{
-  min-height:100vh;
+  min-height:0;
 }
 
 .portal-page .portal-left{
-  position:relative;
-  display:grid;
-  place-items:center;
-  padding:clamp(34px,5vw,76px);
+  position:absolute;
+  inset:0;
+  padding:0;
   background:transparent;
   border:0;
   box-shadow:none;
@@ -1277,13 +1277,18 @@ body{
   align-content:center;
   justify-items:center;
   gap:20px;
-  padding:clamp(30px,5vw,74px);
+  width:min(640px,calc(100% - 40px));
+  padding:clamp(20px,3vw,34px);
   border-radius:0;
   background:transparent;
   border:0;
   box-shadow:none;
   overflow:visible;
   backdrop-filter:none;
+}
+
+.portal-page .portal-card > *{
+  justify-self:center;
 }
 
 .portal-page .portal-card::before{
@@ -1302,6 +1307,7 @@ body{
   gap:12px;
   text-align:center;
   width:min(500px,100%);
+  max-width:100%;
   padding:clamp(22px,3.4vw,36px);
   border-radius:8px;
   background:rgba(255,255,255,.48);
@@ -1450,6 +1456,7 @@ body{
 
 .portal-page .portal-footer-links{
   margin:0;
+  justify-self:center;
   padding:10px 14px;
   border-radius:999px;
   background:rgba(255,255,255,.48);

--- a/html/auth_choice.html
+++ b/html/auth_choice.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Cormorant+Garamond:wght@500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../css/auth.css?v=20260616-video-blend" />
+  <link rel="stylesheet" href="../css/auth.css?v=20260616-video-center" />
 </head>
 <body class="auth-page portal-page">
   <div class="auth-overlay"></div>


### PR DESCRIPTION
## Summary

- Center the full portal sign-in stack on the page instead of keeping it in a right-side column.
- Keep the video as the whole-page background.
- Update auth CSS cache metadata for Render.

## Validation

- Ran npm run build successfully.