### PR TITLE
 Fix live chat layout and message retention

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -4617,6 +4617,73 @@ body.light-mode select optgroup{
   color:#272522;
 }
 
+/* Keep the live chat as a balanced app surface while each side scrolls independently. */
+body[data-page="messages"] .messages-layout--app{
+  min-height:0;
+  height:calc(100vh - 132px);
+  max-height:760px;
+  align-items:stretch;
+  padding:24px 0 32px;
+  overflow:hidden;
+}
+
+body[data-page="messages"] .chat-list-panel,
+body[data-page="messages"] .conversation-panel{
+  min-height:0;
+  max-height:100%;
+  overflow:hidden;
+}
+
+body[data-page="messages"] .chat-list-panel{
+  display:grid;
+  grid-template-rows:auto auto minmax(0,1fr);
+}
+
+body[data-page="messages"] .chat-list{
+  min-height:0;
+  overflow:auto;
+  padding-right:6px;
+}
+
+body[data-page="messages"] .conversation-panel{
+  display:grid;
+  grid-template-rows:auto minmax(0,1fr) auto auto;
+}
+
+body[data-page="messages"] .message-thread{
+  min-height:0;
+  height:auto;
+  overflow:auto;
+  align-content:start;
+  padding-right:6px;
+}
+
+body[data-page="messages"] .quick-actions{
+  margin-top:0;
+}
+
+@media (max-width:1100px){
+  body[data-page="messages"] .messages-layout--app{
+    height:auto;
+    max-height:none;
+    overflow:visible;
+  }
+
+  body[data-page="messages"] .chat-list-panel,
+  body[data-page="messages"] .conversation-panel{
+    max-height:none;
+  }
+
+  body[data-page="messages"] .chat-list{
+    max-height:420px;
+  }
+
+  body[data-page="messages"] .message-thread{
+    min-height:360px;
+    max-height:60vh;
+  }
+}
+
 body.light-mode{
   --bg:#fbf7ef;
   --bg-2:#f3eadb;

--- a/js/site-core.js
+++ b/js/site-core.js
@@ -9,6 +9,7 @@
     user: 'freesewaa-user',
     reviews: 'freesewaa-about-reviews'
   };
+  const MESSAGE_RETENTION_MS = 2 * 24 * 60 * 60 * 1000;
 
   const defaultState = {
     user: {
@@ -285,6 +286,27 @@
 
   function getCurrentUserId() {
     return localStorage.getItem(STORAGE_KEYS.currentUserId) || '';
+  }
+
+  function pruneExpiredLocalMessages() {
+    const cutoff = Date.now() - MESSAGE_RETENTION_MS;
+    let changed = false;
+
+    const beforeConversationCount = appState.conversations.length;
+    appState.conversations = appState.conversations.filter(conversation => {
+      const beforeCount = Array.isArray(conversation.messages) ? conversation.messages.length : 0;
+      conversation.messages = (conversation.messages || []).filter(message => {
+        const createdTime = new Date(message.createdAt || conversation.updatedAt || Date.now()).getTime();
+        return !Number.isFinite(createdTime) || createdTime >= cutoff;
+      });
+      if (conversation.messages.length !== beforeCount) changed = true;
+
+      const updatedTime = new Date(conversation.updatedAt || Date.now()).getTime();
+      return conversation.messages.length || !Number.isFinite(updatedTime) || updatedTime >= cutoff;
+    });
+
+    if (appState.conversations.length !== beforeConversationCount) changed = true;
+    if (changed) saveState();
   }
 
   function isAuthenticated() {
@@ -2008,6 +2030,7 @@
     let isSendingMessage = false;
     let isRefreshingMessages = false;
     sessionStorage.removeItem('freesewaa-open-conversation');
+    pruneExpiredLocalMessages();
 
     async function refreshRemoteConversations(renderAfter = true) {
       if (isRefreshingMessages) return;
@@ -2051,6 +2074,7 @@
 
     function getFilteredConversations() {
       const term = conversationSearch.value.trim().toLowerCase();
+      pruneExpiredLocalMessages();
       const sorted = [...appState.conversations].sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
       return sorted.filter(conversation => {
         const listing = getListingById(conversation.listingId);
@@ -2172,7 +2196,8 @@
             sender: 'You',
             text: trimmed,
             time: new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
-            type: 'sent'
+            type: 'sent',
+            createdAt: new Date().toISOString()
           });
           showToast(error.message || 'Message saved locally. Server chat may be unavailable.', 'error');
         }
@@ -2181,7 +2206,8 @@
           sender: conversation.participant,
           text: trimmed,
           time: new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
-          type
+          type,
+          createdAt: new Date().toISOString()
         });
       }
       conversation.updatedAt = new Date().toISOString();

--- a/server/server.js
+++ b/server/server.js
@@ -17,6 +17,7 @@ const FIREBASE_CERT_URL = 'https://www.googleapis.com/robot/v1/metadata/x509/sec
 const FALLBACK_LISTING_IMAGE = 'https://images.unsplash.com/photo-1517705008128-361805f42e86?auto=format&fit=crop&w=900&q=80';
 const MAX_INLINE_IMAGE_LENGTH = 180000;
 const MAX_REPORT_DETAILS_LENGTH = 500;
+const MESSAGE_RETENTION_MS = 2 * 24 * 60 * 60 * 1000;
 const REPORT_REASONS = new Set([
   'misleading-information',
   'prohibited-item',
@@ -419,6 +420,7 @@ async function ensureIndexes() {
 
   await messagesCollection.createIndex({ conversationId: 1 });
   await messagesCollection.createIndex({ createdAt: 1 });
+  await messagesCollection.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
   await notificationsCollection.createIndex({ id: 1 }, { unique: true });
   await notificationsCollection.createIndex({ userId: 1 });
@@ -441,6 +443,31 @@ async function ensureIndexes() {
     { listingId: 1, reporterId: 1, status: 1 },
     { unique: true, partialFilterExpression: { status: 'open' } }
   );
+}
+
+async function cleanupExpiredMessages() {
+  if (!messagesCollection || !conversationsCollection || !notificationsCollection) return;
+
+  const cutoff = new Date(Date.now() - MESSAGE_RETENTION_MS);
+  const cutoffIso = cutoff.toISOString();
+
+  await messagesCollection.deleteMany({
+    $or: [
+      { createdAt: { $lt: cutoffIso } },
+      { expiresAt: { $lte: new Date() } }
+    ]
+  });
+
+  await notificationsCollection.deleteMany({
+    type: 'message',
+    createdAt: { $lt: cutoffIso }
+  });
+
+  const activeConversationIds = await messagesCollection.distinct('conversationId');
+  await conversationsCollection.deleteMany({
+    updatedAt: { $lt: cutoffIso },
+    id: { $nin: activeConversationIds }
+  });
 }
 
 /**
@@ -2372,6 +2399,7 @@ const server = http.createServer(async (req, res) => {
       if (!userId) {
         return sendJson(res, 400, { error: 'userId is required.' });
       }
+      await cleanupExpiredMessages();
 
       const conversations = await conversationsCollection
         .find({ participantIds: userId })
@@ -2464,6 +2492,7 @@ const server = http.createServer(async (req, res) => {
     if (pathname.match(/^\/api\/messages\/conversations\/[^/]+\/messages$/) && req.method === 'GET') {
       const conversationId = pathname.split('/')[4];
       const userId = getUserId(req, url);
+      await cleanupExpiredMessages();
       const conversation = await conversationsCollection.findOne({ id: conversationId });
       if (!conversation) {
         return sendJson(res, 404, { error: 'Conversation not found.' });
@@ -2531,7 +2560,8 @@ const server = http.createServer(async (req, res) => {
         senderName: user.name || user.firstName || 'You',
         text: messageText,
         type: 'sent',
-        createdAt: new Date().toISOString()
+        createdAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + MESSAGE_RETENTION_MS)
       };
 
       await messagesCollection.insertOne(message);
@@ -2631,6 +2661,7 @@ async function startServer() {
     reportsCollection = db.collection('reports');
 
     await ensureIndexes();
+    await cleanupExpiredMessages();
     await ensureSeedData();
 
     console.log('✅ MongoDB connected');


### PR DESCRIPTION
## Summary

- Keep the Messages page as a bounded two-column chat workspace so the inbox and conversation pane scroll independently.
- Add two-day server-side message retention with MongoDB TTL for new messages and cleanup for older string timestamps.
- Remove stale message notifications and old empty conversations during cleanup.
- Prune expired local fallback messages in the browser.

## Validation

- Ran npm run build successfully.
- Ran node --check server/server.js successfully.
- Ran npm test in server; existing unrelated Firebase/report tests fail, while this change passed syntax/build checks.