### PR TITLE
Update final presentation deck links

### DIFF
--- a/portfolio/07-final-presentation/slides/final ppt.md
+++ b/portfolio/07-final-presentation/slides/final ppt.md
@@ -1,2 +1,20 @@
-[FREE-SEWAA1.pptx](https://github.com/user-attachments/files/28965945/FREE-SEWAA1.pptx)
+# Free Sewaa Final Presentation Deck
 
+## Official Deck
+
+- [Download FREE-SEWAA1.pptx](https://github.com/user-attachments/files/28965945/FREE-SEWAA1.pptx)
+
+## Important Presentation Links
+
+- [Slide driver README](./README.md)
+- [Final presentation script](../FINAL_PRESENTATION_SCRIPT.md)
+- [Technical defense prep](../TECHNICAL_DEFENSE_PREP.md)
+- [Backup demo plan](../BACKUP_DEMO.md)
+- [Final MVP demo](../../04-final-product/FINAL_MVP_DEMO.md)
+- [Final MVP screenshot gallery](../../../docs/assets/screenshots/README.md)
+- [Final portfolio audit](../../FINAL_PORTFOLIO_AUDIT.md)
+- [Live Render deployment](https://free-sewaa-qh05.onrender.com)
+
+## Presenter Note
+
+Use the PowerPoint deck as the main visual artifact, the Render deployment for the live demo, and the screenshot gallery as the backup if the live site is slow or unavailable. Do not show real credentials, phone numbers, private emails, Firebase secrets, or MongoDB credentials during the presentation.


### PR DESCRIPTION
## Summary

Updates the final presentation deck note so the existing PowerPoint attachment is clearly labeled as the official deck and connected to the strongest presentation evidence.

## What Changed

- Added the official FREE-SEWAA1.pptx download link.
- Added important presentation links for the slide driver, script, defense prep, backup demo, Final MVP demo, screenshots, audit, and live Render deployment.
- Added a short presenter note about using Render first and avoiding private data during the demo.

## Verification

- git diff --check
- Relative Markdown links validated
- PPTX attachment and Render deployment checked
