### PR TITLE
[codex] Polish message unread badge display

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -178,12 +178,12 @@ body.light-mode .icon-link:hover, body.light-mode .active-link{
 }
 .message-count-badge{
   position:absolute;
-  top:2px;
-  right:1px;
+  top:5px;
+  right:5px;
   z-index:3;
-  min-width:19px;
-  height:19px;
-  padding:0 5px;
+  min-width:18px;
+  height:18px;
+  padding:0 4px;
   border-radius:999px;
   display:inline-grid;
   place-items:center;
@@ -195,11 +195,8 @@ body.light-mode .icon-link:hover, body.light-mode .active-link{
   font-weight:800;
   line-height:1;
 }
-.message-count-badge[hidden]{display:none}
-.icon-link.has-nav-icon:hover .message-count-badge,
-.icon-link.has-nav-icon:focus-visible .message-count-badge{
-  right:8px;
-}
+.message-count-badge[hidden],
+.message-count-badge:empty{display:none}
 .icon-link.has-unread-messages{
   border-color:transparent;
 }

--- a/js/site-core.js
+++ b/js/site-core.js
@@ -2674,8 +2674,8 @@
         link.appendChild(badge);
       }
 
-      badge.textContent = unread;
-      badge.hidden = unread === 0;
+      badge.textContent = unread > 0 ? unread : '';
+      badge.hidden = unread <= 0;
       link.classList.toggle('has-unread-messages', unread > 0);
       link.setAttribute('aria-label', labelText);
       link.setAttribute('title', labelText);


### PR DESCRIPTION
## Summary
- Move the message unread badge fully into view on the header icon.
- Keep the red badge visually closer to Facebook/Messenger: small, round, and pinned to the top-right of the message icon.
- Prevent zero unread counts from rendering text in the badge; only positive counts like `1` or `2` are shown.

## Validation
- Ran `npm run build` successfully.

## Root cause
The previous badge sat too close to the icon edge and still wrote `0` into the badge before hiding it, which could make a clipped zero visible during rendering.