### PR TITLE
Fix language selector behavior

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -228,6 +228,96 @@ body.light-mode .settings-menu a:hover, body.light-mode .settings-button:hover{
   background:rgba(42,32,23,.08);
   color:var(--text);
 }
+.language-selector{
+  position:relative;
+}
+.language-selector summary{
+  width:82px;
+  height:44px;
+  padding:0 12px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+  border:1px solid transparent;
+  border-radius:999px;
+  color:var(--muted);
+  cursor:pointer;
+  list-style:none;
+  transition:background .22s ease,color .22s ease,border-color .22s ease;
+}
+.language-selector summary::-webkit-details-marker{display:none}
+.language-selector summary:focus-visible{outline:2px solid var(--bronze);outline-offset:2px}
+.language-selector[open] summary,
+.language-selector summary:hover{
+  color:var(--text);
+  background:rgba(42,32,23,.06);
+  border-color:rgba(42,32,23,.12);
+}
+.language-selector__icon{
+  width:17px;
+  height:17px;
+  flex:0 0 auto;
+}
+.language-selector__code{
+  font-size:.82rem;
+  font-weight:900;
+  letter-spacing:.02em;
+}
+.language-selector__chevron{
+  width:8px;
+  height:8px;
+  border-right:2px solid currentColor;
+  border-bottom:2px solid currentColor;
+  transform:rotate(45deg) translate(-1px,-1px);
+  transition:transform .18s ease;
+}
+.language-selector[open] .language-selector__chevron{transform:rotate(225deg) translate(-1px,-1px)}
+.language-selector__menu{
+  position:absolute;
+  right:0;
+  top:calc(100% + 10px);
+  z-index:80;
+  min-width:230px;
+  padding:8px;
+  display:grid;
+  gap:2px;
+  border:1px solid var(--line);
+  border-radius:8px;
+  background:color-mix(in srgb, var(--panel) 96%, transparent);
+  box-shadow:var(--shadow);
+}
+.language-selector__option{
+  width:100%;
+  min-height:42px;
+  padding:8px 10px;
+  display:grid;
+  grid-template-columns:16px 34px minmax(0,1fr);
+  align-items:center;
+  gap:10px;
+  border:0;
+  border-radius:8px;
+  background:transparent;
+  color:var(--muted);
+  cursor:pointer;
+  text-align:left;
+}
+.language-selector__option:hover,
+.language-selector__option.is-active{
+  color:var(--text);
+  background:rgba(42,32,23,.07);
+}
+.language-selector__check{
+  opacity:0;
+  color:#2f7773;
+  font-weight:900;
+}
+.language-selector__option.is-active .language-selector__check{opacity:1}
+.language-selector__flag{
+  font-size:.72rem;
+  font-weight:900;
+  color:var(--soft);
+}
 .btn{
   display:inline-flex; align-items:center; justify-content:center;
   padding:12px 18px; border-radius:16px; font-weight:600;

--- a/js/language-pages.js
+++ b/js/language-pages.js
@@ -1,6 +1,114 @@
 (function () {
   const LANGUAGE_KEY = 'freesewaa-language';
 
+  const commonText = {
+    ko: {
+      Home: '홈',
+      'About Us': '소개',
+      Donate: '기부',
+      Browse: '찾기',
+      Events: '행사',
+      'Donate Us': '후원',
+      Notifications: '알림',
+      Messages: '메시지',
+      Settings: '설정',
+      'My Posts': '내 게시물',
+      'Track Your Request': '요청 확인',
+      'Free Services': '무료 서비스',
+      'Personal Information': '개인 정보',
+      'Edit Profile': '프로필 수정',
+      'Change Region': '지역 변경',
+      'Saved Items': '저장한 항목',
+      'My Requests': '내 요청',
+      'Toggle Dark Mode': '다크 모드 전환',
+      Logout: '로그아웃'
+    },
+    ne: {
+      Home: 'गृह',
+      'About Us': 'हाम्रो बारेमा',
+      Donate: 'दान',
+      Browse: 'खोज्नुहोस्',
+      Events: 'कार्यक्रम',
+      'Donate Us': 'हामीलाई सहयोग',
+      Notifications: 'सूचना',
+      Messages: 'सन्देश',
+      Settings: 'सेटिङ',
+      'My Posts': 'मेरा पोस्ट',
+      'Track Your Request': 'अनुरोध हेर्नुहोस्',
+      'Free Services': 'निःशुल्क सेवा',
+      'Personal Information': 'व्यक्तिगत जानकारी',
+      'Edit Profile': 'प्रोफाइल सम्पादन',
+      'Change Region': 'क्षेत्र बदल्नुहोस्',
+      'Saved Items': 'सुरक्षित सामान',
+      'My Requests': 'मेरा अनुरोध',
+      'Toggle Dark Mode': 'डार्क मोड बदल्नुहोस्',
+      Logout: 'लगआउट'
+    },
+    hi: {
+      Home: 'होम',
+      'About Us': 'हमारे बारे में',
+      Donate: 'दान करें',
+      Browse: 'ब्राउज़',
+      Events: 'कार्यक्रम',
+      'Donate Us': 'हमें सहयोग दें',
+      Notifications: 'सूचनाएं',
+      Messages: 'संदेश',
+      Settings: 'सेटिंग्स',
+      'My Posts': 'मेरी पोस्ट',
+      'Track Your Request': 'अनुरोध ट्रैक करें',
+      'Free Services': 'निःशुल्क सेवाएं',
+      'Personal Information': 'व्यक्तिगत जानकारी',
+      'Edit Profile': 'प्रोफाइल संपादित करें',
+      'Change Region': 'क्षेत्र बदलें',
+      'Saved Items': 'सेव किए गए आइटम',
+      'My Requests': 'मेरे अनुरोध',
+      'Toggle Dark Mode': 'डार्क मोड बदलें',
+      Logout: 'लॉगआउट'
+    },
+    vi: {
+      Home: 'Trang chủ',
+      'About Us': 'Giới thiệu',
+      Donate: 'Quyên góp',
+      Browse: 'Tìm kiếm',
+      Events: 'Sự kiện',
+      'Donate Us': 'Ủng hộ',
+      Notifications: 'Thông báo',
+      Messages: 'Tin nhắn',
+      Settings: 'Cài đặt',
+      'My Posts': 'Bài đăng của tôi',
+      'Track Your Request': 'Theo dõi yêu cầu',
+      'Free Services': 'Dịch vụ miễn phí',
+      'Personal Information': 'Thông tin cá nhân',
+      'Edit Profile': 'Sửa hồ sơ',
+      'Change Region': 'Đổi khu vực',
+      'Saved Items': 'Mục đã lưu',
+      'My Requests': 'Yêu cầu của tôi',
+      'Toggle Dark Mode': 'Đổi chế độ tối',
+      Logout: 'Đăng xuất'
+    },
+    fil: {
+      Home: 'Home',
+      'About Us': 'Tungkol Sa Amin',
+      Donate: 'Mag-donate',
+      Browse: 'Maghanap',
+      Events: 'Events',
+      'Donate Us': 'Suportahan Kami',
+      Notifications: 'Notifications',
+      Messages: 'Messages',
+      Settings: 'Settings',
+      'My Posts': 'Aking Posts',
+      'Track Your Request': 'I-track ang Request',
+      'Free Services': 'Free Services',
+      'Personal Information': 'Personal na Impormasyon',
+      'Edit Profile': 'I-edit ang Profile',
+      'Change Region': 'Palitan ang Rehiyon',
+      'Saved Items': 'Saved Items',
+      'My Requests': 'Aking Requests',
+      'Toggle Dark Mode': 'Palitan ang Dark Mode',
+      Logout: 'Logout'
+    }
+  };
+
   const pageText = {
     ne: {
       'CREATE A LISTING': 'सूची बनाउनुहोस्',
@@ -115,7 +223,7 @@
   }
 
   function translateTextNodes(lang) {
-    const dictionary = pageText[lang] || {};
+    const dictionary = { ...(commonText[lang] || {}), ...(pageText[lang] || {}) };
     const selector = 'a,button,span,p,h1,h2,h3,strong,label,option,.mini-label,.eyebrow,.stat-label,.section-title,.page-title';
 
     document.querySelectorAll(selector).forEach((element) => {
@@ -139,7 +247,7 @@
   }
 
   function translatePlaceholders(lang) {
-    const dictionary = pageText[lang] || {};
+    const dictionary = { ...(commonText[lang] || {}), ...(pageText[lang] || {}) };
 
     document.querySelectorAll('input[placeholder], textarea[placeholder]').forEach((element) => {
       const key = rememberPlaceholder(element);
@@ -171,31 +279,60 @@
 
   function applyPageLanguage() {
     const lang = selectedLanguage();
-    const hasPageDictionary = Boolean(pageText[lang]);
+    const hasPageDictionary = Boolean(pageText[lang] || commonText[lang]);
     const hasRememberedText = Boolean(document.querySelector('[data-page-i18n-key], [data-page-i18n-placeholder]'));
 
     if (!hasPageDictionary && (lang !== 'en' || !hasRememberedText)) return;
 
+    document.documentElement.lang = lang;
     translateTextNodes(lang);
     translatePlaceholders(lang);
     translateDynamicScore(lang);
   }
 
+  function updateLanguageSelectors(lang = selectedLanguage()) {
+    document.querySelectorAll('.language-selector').forEach((selector) => {
+      const options = Array.from(selector.querySelectorAll('.language-selector__option'));
+      const active = options.find((option) => option.dataset.lang === lang) || options.find((option) => option.dataset.lang === 'en');
+      const code = selector.querySelector('.language-selector__code');
+
+      options.forEach((option) => {
+        option.classList.toggle('is-active', option === active);
+        option.setAttribute('aria-pressed', option === active ? 'true' : 'false');
+      });
+
+      if (code && active) code.textContent = active.dataset.code || 'EN';
+    });
+  }
+
+  function setLanguage(lang) {
+    localStorage.setItem(LANGUAGE_KEY, lang);
+    updateLanguageSelectors(lang);
+    applyPageLanguage();
+    window.dispatchEvent(new CustomEvent('freesewaa-language-change', { detail: { lang } }));
+  }
+
   function scheduleApply() {
     [0, 80, 250, 700, 1400].forEach((delay) => {
-      window.setTimeout(applyPageLanguage, delay);
+      window.setTimeout(() => {
+        updateLanguageSelectors();
+        applyPageLanguage();
+      }, delay);
     });
   }
 
   document.addEventListener('click', (event) => {
-    if (event.target.closest('.language-selector__option')) {
-      scheduleApply();
-    }
+    const option = event.target.closest('.language-selector__option');
+    if (!option) return;
+    setLanguage(option.dataset.lang || 'en');
+    option.closest('.language-selector')?.removeAttribute('open');
   });
 
   document.addEventListener('input', () => {
     if (selectedLanguage() !== 'en') scheduleApply();
   });
+
+  window.addEventListener('freesewaa-language-controls-ready', scheduleApply);
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', scheduleApply);

--- a/js/site-core.js
+++ b/js/site-core.js
@@ -423,6 +423,7 @@
       try {
         appState = normalizeState(JSON.parse(event.newValue));
         enhanceMenus();
+        enhanceLanguageSelectors();
         enhanceNavIcons();
         updateMessageNavStatus();
         initCurrentPage();
@@ -2705,6 +2706,37 @@
     });
   }
 
+  function enhanceLanguageSelectors() {
+    document.querySelectorAll('.header-actions').forEach(actions => {
+      if (actions.querySelector('.language-selector')) return;
+
+      const settings = actions.querySelector('.settings-dropdown');
+      const selector = document.createElement('details');
+      selector.className = 'language-selector';
+      selector.innerHTML = `
+        <summary aria-label="Choose language">
+          <svg class="language-selector__icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2"></circle>
+            <path d="M3 12h18M12 3c2.3 2.5 3.4 5.5 3.4 9s-1.1 6.5-3.4 9M12 3c-2.3 2.5-3.4 5.5-3.4 9s1.1 6.5 3.4 9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
+          </svg>
+          <span class="language-selector__code">EN</span>
+          <span class="language-selector__chevron" aria-hidden="true"></span>
+        </summary>
+        <div class="language-selector__menu" role="menu">
+          <button class="language-selector__option is-active" type="button" data-lang="en" data-code="EN" role="menuitem"><span class="language-selector__check">✓</span><span class="language-selector__flag">EN</span><span>English</span></button>
+          <button class="language-selector__option" type="button" data-lang="ko" data-code="KO" role="menuitem"><span class="language-selector__check">✓</span><span class="language-selector__flag">KO</span><span>Korean</span></button>
+          <button class="language-selector__option" type="button" data-lang="ne" data-code="NE" role="menuitem"><span class="language-selector__check">✓</span><span class="language-selector__flag">NE</span><span>Nepali</span></button>
+          <button class="language-selector__option" type="button" data-lang="hi" data-code="HI" role="menuitem"><span class="language-selector__check">✓</span><span class="language-selector__flag">HI</span><span>Hindi</span></button>
+          <button class="language-selector__option" type="button" data-lang="vi" data-code="VI" role="menuitem"><span class="language-selector__check">✓</span><span class="language-selector__flag">VI</span><span>Vietnamese</span></button>
+          <button class="language-selector__option" type="button" data-lang="fil" data-code="FIL" role="menuitem"><span class="language-selector__check">✓</span><span class="language-selector__flag">FIL</span><span>Filipino</span></button>
+        </div>
+      `;
+
+      actions.insertBefore(selector, settings || actions.lastElementChild);
+    });
+    window.dispatchEvent(new Event('freesewaa-language-controls-ready'));
+  }
+
   function setFormStatus(element, message, tone = 'default') {
     if (!element) return;
     element.textContent = message;
@@ -3392,6 +3424,7 @@
     if (!isAuthenticated()) {
       if (isPublicPage) {
         enhancePublicActions();
+        enhanceLanguageSelectors();
         enhanceNavIcons();
         initCurrentPage();
         return;
@@ -3415,6 +3448,7 @@
     initChatbotWidget();
     enhanceMenus();
     enhancePublicActions();
+    enhanceLanguageSelectors();
     enhanceNavIcons();
     initCurrentPage();
   }


### PR DESCRIPTION
## Summary
- Add the language selector to app headers that were missing it.
- Move language selector styling into the shared theme stylesheet.
- Make language changes persist, update the active state/code, close the menu after selection, and apply common header/settings translations.

## Validation
- Ran `npm run build` successfully.

## Root cause
The language selector markup and styling lived mostly inside `app.html`, while other app pages did not share the same control. The shared language script also did not reliably update selector state across pages.